### PR TITLE
Fixed Ship Stats not being updated due to upgrades

### DIFF
--- a/mic/src/mic/VassalXWSPilotPieces.java
+++ b/mic/src/mic/VassalXWSPilotPieces.java
@@ -220,7 +220,7 @@ public class VassalXWSPilotPieces {
 
         return piece;
     }
-
+/*
     public GamePiece cloneShip() {
         GamePiece piece = Util.newPiece(this.ship);
 
@@ -299,7 +299,7 @@ public class VassalXWSPilotPieces {
         }
         return piece;
     }
-
+*/
     private GamePiece configureStemShip(String slotName, String faction, MasterShipData.ShipData shipData, GamePiece piece)
     {
         StringBuilder prototypePrefixSB = new StringBuilder();


### PR DESCRIPTION
Veteran Instincts, Shield Upgrade, Hull Upgrade, Stealth Device, Punishing One, Heavy Scyk, etc, all now properly update ship stats.

Also fixed Pivot Wing and Adaptability not sending a log to chat reminding player to set the proper stats.